### PR TITLE
meson fix comparison

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -313,7 +313,7 @@ if not opt_asm.disabled()
         endif
       endif
 
-      if cc.get_define('__APPLE__')
+      if cc.get_define('__APPLE__') != ''
         arm2gnu_args = ['--apple']
       else
         arm2gnu_args = []


### PR DESCRIPTION
cc.get_define returns str (not bool)

Fixes:
Fetching value of define "__APPLE__" :  
../meson.build:316:12: ERROR: Object <[StringHolder] holds [str]: ''> of type str does not support the `bool()` operator.